### PR TITLE
Rename and restructure

### DIFF
--- a/linq/__init__.py
+++ b/linq/__init__.py
@@ -1,0 +1,7 @@
+from . import errors
+from ._grouping import Grouping
+from ._joining import Joining
+from ._query import Query
+
+
+__all__ = ["Query", "Grouping", "Joining", "errors"]

--- a/linq/_grouping.py
+++ b/linq/_grouping.py
@@ -1,0 +1,36 @@
+from typing import Generic, TypeVar, Sequence, List
+
+KT = TypeVar("KT")
+VT = TypeVar("VT")
+
+
+class Grouping(Generic[KT, VT]):
+    """Sequence of values grouped under one key. This object is initialized by some
+    query methods."""
+
+    def __init__(self, key: KT, values: Sequence[VT]):
+        """
+        Args:
+            key (KT): Key.
+            values (Sequence[VT]): Sequence of values associated to `key`.
+        """
+        self._values = list(values)
+        self._key = key
+
+    @property
+    def values(self) -> List[VT]:
+        """Values."""
+        return self._values
+
+    @property
+    def key(self) -> KT:
+        """Key."""
+        return self._key
+
+    def __iter__(self):
+        yield from self._values
+
+    def __repr__(self):
+        return {
+            self._key: self._values
+        }.__repr__()

--- a/linq/_joining.py
+++ b/linq/_joining.py
@@ -1,0 +1,28 @@
+from typing import Generic, TypeVar, Iterable, List
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+
+class Joining(Generic[T, S]):
+
+    def __init__(self, inner: T, outer: Iterable[S]):
+        self._inner = inner
+        self._outer = outer
+
+    @property
+    def inner(self) -> T:
+        return self._inner
+
+    @property
+    def outer(self) -> List[S]:
+        return self._outer
+
+    def __iter__(self):
+        yield from self._outer
+
+    def __repr__(self):
+        return {
+            "inner": self._inner,
+            "outer": self._outer
+        }.__repr__()

--- a/linq/errors/__init__.py
+++ b/linq/errors/__init__.py
@@ -1,0 +1,7 @@
+"""Errors raised by queries."""
+
+
+from ._no_such_element_error import NoSuchElementError
+
+
+__all__ = ["NoSuchElementError"]

--- a/linq/errors/_no_such_element_error.py
+++ b/linq/errors/_no_such_element_error.py
@@ -1,4 +1,6 @@
 class NoSuchElementError(Exception):
+    """Raised whenever a requested element was not retrievable."""
+
     def __init__(self, err=""):
         self.err = err
 

--- a/python_linq/__init__.py
+++ b/python_linq/__init__.py
@@ -1,5 +1,0 @@
-from ._core import From, Grouping, Joining
-from ._linq_exceptions import NoSuchElementError
-
-
-__all__ = ["From", "Grouping", "Joining", "NoSuchElementError"]

--- a/tests/test_linq.py
+++ b/tests/test_linq.py
@@ -1,4 +1,4 @@
-from python_linq import From, Grouping, NoSuchElementError
+from linq import Query, Grouping, errors
 import unittest
 
 class TestBasicFunctions(unittest.TestCase):
@@ -15,9 +15,9 @@ class TestBasicFunctions(unittest.TestCase):
         ]
 
     def test_all(self):
-        self.assertFalse(From([1, 2, 3, 4, 5, 6]).all(lambda x: x == 4))
+        self.assertFalse(Query([1, 2, 3, 4, 5, 6]).all(lambda x: x == 4))
 
-        self.assertTrue(From([1, 2, 3, 4, 5, 6]).all(lambda x: x < 7))
+        self.assertTrue(Query([1, 2, 3, 4, 5, 6]).all(lambda x: x < 7))
 
         subject = [
             {
@@ -29,15 +29,15 @@ class TestBasicFunctions(unittest.TestCase):
             }
         ]
         self.assertTrue(
-            From(subject).any(
+            Query(subject).any(
                 lambda x: x["value"] == 2 or x["value"] == 3
             )
         )
 
     def test_any(self):
-        self.assertTrue(From([1, 2, 3, 4, 5, 6]).any(lambda x: x == 4))
+        self.assertTrue(Query([1, 2, 3, 4, 5, 6]).any(lambda x: x == 4))
 
-        self.assertFalse(From([1, 2, 3, 4, 5, 6]).any(lambda x: x > 6))
+        self.assertFalse(Query([1, 2, 3, 4, 5, 6]).any(lambda x: x > 6))
 
         subject = [
             {
@@ -48,17 +48,17 @@ class TestBasicFunctions(unittest.TestCase):
                 "value": 3
             }
         ]
-        self.assertTrue(From(subject).any(lambda x: x["value"] == 2))
+        self.assertTrue(Query(subject).any(lambda x: x["value"] == 2))
 
     def test_average(self):
         subject = [1, 2, 3, 4, 5]
         self.assertEqual(
-            From(subject).average(),
+            Query(subject).average(),
             3
         )
 
         self.assertEqual(
-            From(subject).select(lambda x: x*x).average(),
+            Query(subject).select(lambda x: x*x).average(),
             11
         )
 
@@ -68,7 +68,7 @@ class TestBasicFunctions(unittest.TestCase):
             { "value": 3 }
         ]
         self.assertEqual(
-            From(subject).select(lambda x: x["value"]).average(),
+            Query(subject).select(lambda x: x["value"]).average(),
             2
         )
 
@@ -78,7 +78,7 @@ class TestBasicFunctions(unittest.TestCase):
         subjectB = [4, 5, 6]
         
         self.assertListEqual(
-            From(subjectA).concat(subjectB).toList(),
+            Query(subjectA).concat(subjectB).toList(),
             [1, 2, 3, 4, 5, 6]
         )
 
@@ -91,25 +91,25 @@ class TestBasicFunctions(unittest.TestCase):
             { "value": 4 }
         ]
         self.assertListEqual(
-            From(subjectA).select(lambda x: x["value"]).concat(
-                From(subjectB).select(lambda x: x["value"])
+            Query(subjectA).select(lambda x: x["value"]).concat(
+                Query(subjectB).select(lambda x: x["value"])
             ).toList(),
             [1, 2, 3, 4]
         )
 
     def test_contains(self):
-        self.assertTrue(From([1, 2, 3, 4]).contains(2))
+        self.assertTrue(Query([1, 2, 3, 4]).contains(2))
 
-        self.assertFalse(From([1, 2, 3, 4]).contains(5))
+        self.assertFalse(Query([1, 2, 3, 4]).contains(5))
 
     def test_count(self):
         self.assertEqual(
-            From([1, 2, 3, 4, 5, 6]).count(),
+            Query([1, 2, 3, 4, 5, 6]).count(),
             6
         )
 
         self.assertEqual(
-            From([1, 2, 3, 4, 5, 6]).count(lambda x: x > 3),
+            Query([1, 2, 3, 4, 5, 6]).count(lambda x: x > 3),
             3
         )
 
@@ -123,14 +123,14 @@ class TestBasicFunctions(unittest.TestCase):
             }
         ]
         self.assertEqual(
-            From(subject).count(lambda x: x["value"] > 2),
+            Query(subject).count(lambda x: x["value"] > 2),
             1
         )
 
     def test_distinct(self):
         subject = [1, 1, 2, 3, 3, 3]
         self.assertListEqual(
-            From(subject).distinct().toList(),
+            Query(subject).distinct().toList(),
             [1, 2, 3]
         )
 
@@ -150,14 +150,14 @@ class TestBasicFunctions(unittest.TestCase):
             }
         ]
         self.assertListEqual(
-            From(subject).distinct(lambda x: x["id"]).select(lambda x: x["value"]).toList(),
+            Query(subject).distinct(lambda x: x["id"]).select(lambda x: x["value"]).toList(),
             [3, 4]
         )
 
         expected = [1,2,3,4]
         subject = [1,1,1,1,1,1,1,1,2,3,3,3,3,3,4]
 
-        result = From(subject).distinct().toList()
+        result = Query(subject).distinct().toList()
 
         self.assertListEqual(expected, result)
 
@@ -183,26 +183,26 @@ class TestBasicFunctions(unittest.TestCase):
         ]
         expected = [1, 2, 3]
 
-        result = From(subject).distinct(lambda x: x["value"]).select(lambda x: x["value"]).toList()
+        result = Query(subject).distinct(lambda x: x["value"]).select(lambda x: x["value"]).toList()
 
         self.assertListEqual(expected,result)
 
     def test_elementat(self):
         subject = [1, 2, 3, 4]
         self.assertEqual(
-            From(subject).elementAt(2),
+            Query(subject).elementAt(2),
             3
         )
 
         with self.assertRaises(IndexError):
-            From(subject).elementAt(4)
+            Query(subject).elementAt(4)
 
         subject = [
             { "value": 1 },
             { "value": 2 }
         ]
         self.assertDictEqual(
-            From(subject).elementAt(0),
+            Query(subject).elementAt(0),
             { "value": 1 }
         )
 
@@ -210,71 +210,71 @@ class TestBasicFunctions(unittest.TestCase):
         
         subject = [1, 2, 3, 4]
         self.assertEqual(
-            From(subject).elementAtOrNone(2),
+            Query(subject).elementAtOrNone(2),
             3
         )
 
-        self.assertIsNone(From(subject).elementAtOrNone(4))
+        self.assertIsNone(Query(subject).elementAtOrNone(4))
 
         subject = [
             { "value": 1 },
             { "value": 2 }
         ]
         self.assertDictEqual(
-            From(subject).elementAtOrNone(0),
+            Query(subject).elementAtOrNone(0),
             { "value": 1 }
         )
 
     def test_first(self):
         subject = [1, 2, 3, 4]
         self.assertEqual(
-            From(subject).first(lambda x: x % 2 == 0),
+            Query(subject).first(lambda x: x % 2 == 0),
             2
         )
 
         self.assertEqual(
-            From(subject).first(),
+            Query(subject).first(),
             1
         )
 
-        with self.assertRaises(NoSuchElementError):
-            From(subject).first(lambda x: x > 4)
+        with self.assertRaises(errors.NoSuchElementError):
+            Query(subject).first(lambda x: x > 4)
 
         subject = [
             { "value": 1 },
             { "value": 2 }
         ]
         self.assertDictEqual(
-            From(subject).first(lambda x: x["value"] == 2),
+            Query(subject).first(lambda x: x["value"] == 2),
             { "value": 2 }
         )
 
         expected = 2
-        result = From(self.simple).first()
+        result = Query(self.simple).first()
         self.assertEqual(expected, result)
 
         expected = 3
-        result = From(self.simple).first(lambda x: x % 2 != 0)
+        result = Query(self.simple).first(lambda x: x % 2 != 0)
         self.assertEqual(expected, result)
 
-        with self.assertRaises(NoSuchElementError):
-            From(self.simple).first(lambda x: x > 5)
+        with self.assertRaises(errors.NoSuchElementError):
+            Query(self.simple).first(lambda x: x > 5)
 
     def test_firstornone(self):
         subject = [1, 2, 3, 4]
         self.assertEqual(
-            From(subject).firstOrNone(lambda x: x % 2 == 0),
+            Query(subject).firstOrNone(lambda x: x % 2 == 0),
             2
         )
 
-        self.assertIsNone(From(subject).firstOrNone(lambda x: x > 4))
+        self.assertIsNone(Query(subject).firstOrNone(lambda x: x > 4))
 
         subject = [ 
             { "value": 1 },
             { "value": 2 }
         ]
         self.assertDictEqual(
-            From(subject).first(lambda x: x["value"] == 2),
+            Query(subject).first(lambda x: x["value"] == 2),
             { "value": 2 }
         )
 
@@ -307,7 +307,7 @@ class TestBasicFunctions(unittest.TestCase):
         ]
 
         result = (
-            From(subject)
+            Query(subject)
             .groupBy(lambda x: x["id"], lambda x: x["data"])
             .select(lambda x: x.values)
             .toList()
@@ -316,10 +316,10 @@ class TestBasicFunctions(unittest.TestCase):
         self.assertListEqual(result, expected)
 
         result = (
-            From(subject)
+            Query(subject)
             .groupBy(lambda x: x["id"], lambda x: x["data"])
             .select(
-                lambda x: From(x.values).max()
+                lambda x: Query(x.values).max()
             )
             .toList()
         )
@@ -342,7 +342,7 @@ class TestBasicFunctions(unittest.TestCase):
         # Keys
         self.assertListEqual(
 
-            From(subject).groupBy(
+            Query(subject).groupBy(
                 lambda x: x["age"], 
                 transform = lambda x: x["name"]
             ).select(lambda x: x.key).toList(),
@@ -353,7 +353,7 @@ class TestBasicFunctions(unittest.TestCase):
         # Names
         self.assertListEqual(
             
-            From(subject).groupBy(
+            Query(subject).groupBy(
                 lambda x: x["age"],
                 transform=lambda x: x["name"]
             ).select(lambda x: x.values).toList(),
@@ -365,7 +365,7 @@ class TestBasicFunctions(unittest.TestCase):
         subject1 = [1,2,3,4]
         subject2 = [3,4,5,6]
 
-        result = From(subject1).intersect(subject2).toList()
+        result = Query(subject1).intersect(subject2).toList()
         expected = [3,4]
         self.assertListEqual(result,expected)
 
@@ -387,14 +387,14 @@ class TestBasicFunctions(unittest.TestCase):
                 "value": 5
             }
         ]
-        result = From(subjectA).intersect(subjectB, key=lambda x: x["id"]).select(lambda x: x["value"]).toList()
+        result = Query(subjectA).intersect(subjectB, key=lambda x: x["id"]).select(lambda x: x["value"]).toList()
         expected = [4]
         self.assertListEqual(expected, result)
 
         subjectA = [1, 2, 3, 4]
         subjectB = [3, 4, 5, 6]
         self.assertListEqual(
-            From(subjectA).intersect(subjectB).toList(),
+            Query(subjectA).intersect(subjectB).toList(),
             [3, 4]
         )
 
@@ -417,43 +417,43 @@ class TestBasicFunctions(unittest.TestCase):
             }
         ]
         self.assertListEqual(
-            From(subjectA).intersect(subjectB, key=lambda x: x["id"]).select(lambda x: x["value"]).toList(),
+            Query(subjectA).intersect(subjectB, key=lambda x: x["id"]).select(lambda x: x["value"]).toList(),
             [4]
         )
 
     def test_last(self):
         subject = [1, 2, 3, 4]
         self.assertEqual(
-            From(subject).last(lambda x: x < 4),
+            Query(subject).last(lambda x: x < 4),
             3
         )
 
         self.assertEqual(
-            From(subject).last(),
+            Query(subject).last(),
             4
         )
 
-        with self.assertRaises(NoSuchElementError):
-            From(subject).last(lambda x: x > 4)
+        with self.assertRaises(errors.NoSuchElementError):
+            Query(subject).last(lambda x: x > 4)
 
         subject = [
             { "value": 1 },
             { "value": 2 }
         ]
         self.assertDictEqual(
-            From(subject).last(lambda x: x["value"] > 0),
+            Query(subject).last(lambda x: x["value"] > 0),
             { "value": 2 }
         )
 
     def test_lastornone(self):
         subject = [1, 2, 3, 4]
         self.assertEqual(
-            From(subject).lastOrNone(lambda x: x % 2 == 0),
+            Query(subject).lastOrNone(lambda x: x % 2 == 0),
             4
         )
 
         self.assertIsNone(
-            From(subject).lastOrNone(lambda x: x > 4)
+            Query(subject).lastOrNone(lambda x: x > 4)
         )
 
         subject = [ 
@@ -461,14 +461,14 @@ class TestBasicFunctions(unittest.TestCase):
             { "value": 2 }
         ]
         self.assertDictEqual(
-            From(subject).last(lambda x: x["value"] > 0),
+            Query(subject).last(lambda x: x["value"] > 0),
             { "value": 2 }
         )
 
     def test_argmax(self):
         subject = [1, 2, 3, 4]
         self.assertEqual(
-            From(subject).argmax(lambda x: x),
+            Query(subject).argmax(lambda x: x),
             4
         )
 
@@ -477,14 +477,14 @@ class TestBasicFunctions(unittest.TestCase):
             { "value" : 2 }
         ]
         self.assertEqual(
-            From(subject).argmax(lambda x: x["value"]),
+            Query(subject).argmax(lambda x: x["value"]),
             { "value": 2 }
         )
 
     def test_max(self):
         subject = [1, 2, 3, 4]
         self.assertEqual(
-            From(subject).max(),
+            Query(subject).max(),
             4
         )
 
@@ -493,14 +493,14 @@ class TestBasicFunctions(unittest.TestCase):
             { "value" : 2 }
         ]
         self.assertEqual(
-            From(subject).select(lambda x: x["value"]).max(),
+            Query(subject).select(lambda x: x["value"]).max(),
             2
         )
 
     def test_argmin(self):
         subject = [1, 2, 3, 4]
         self.assertEqual(
-            From(subject).argmin(lambda x: x),
+            Query(subject).argmin(lambda x: x),
             1
         )
 
@@ -509,14 +509,14 @@ class TestBasicFunctions(unittest.TestCase):
             { "value" : 2 }
         ]
         self.assertEqual(
-            From(subject).argmin(lambda x: x["value"]),
+            Query(subject).argmin(lambda x: x["value"]),
             { "value": 1 }
         )
 
     def test_min(self):
         subject = [1, 2, 3, 4]
         self.assertEqual(
-            From(subject).min(),
+            Query(subject).min(),
             1
         )
 
@@ -525,7 +525,7 @@ class TestBasicFunctions(unittest.TestCase):
             { "value" : 2 }
         ]
         self.assertEqual(
-            From(subject).select(lambda x: x["value"]).min(),
+            Query(subject).select(lambda x: x["value"]).min(),
             1
         )
 
@@ -540,7 +540,7 @@ class TestBasicFunctions(unittest.TestCase):
             }
         ]
         self.assertListEqual(
-            From(subject).select(lambda x: x["value"]).toList(),
+            Query(subject).select(lambda x: x["value"]).toList(),
             [2, 3]
         )
 
@@ -551,13 +551,13 @@ class TestBasicFunctions(unittest.TestCase):
             }
         
         self.assertListEqual(
-            From(subject).select(shape).toList(),
+            Query(subject).select(shape).toList(),
             [ {"value": 1}, {"value": 2} ]
         )
 
     def test_selectmany(self):
         expected = [1, 2, 3, 4]
-        obj = From([[1, 2], [3, 4]])
+        obj = Query([[1, 2], [3, 4]])
 
         result = obj.selectMany().toList()
 
@@ -568,7 +568,7 @@ class TestBasicFunctions(unittest.TestCase):
             [5, 6, 7, 8]
         ]
         self.assertListEqual(
-            From(subject).selectMany().toList(),
+            Query(subject).selectMany().toList(),
             [1, 2, 3, 4, 5, 6, 7, 8]
         )
 
@@ -577,19 +577,19 @@ class TestBasicFunctions(unittest.TestCase):
             [{"value": 3}, {"value": 4}]
         ]
         self.assertListEqual(
-            From(subject).selectMany(lambda x: x["value"]).toList(),
+            Query(subject).selectMany(lambda x: x["value"]).toList(),
             [1, 2, 3, 4]
         )
 
     def test_sum(self):
         subject = [1, 2, 3, 4, 5]
         self.assertEqual(
-            From(subject).sum(),
+            Query(subject).sum(),
             15
         )
 
         self.assertEqual(
-            From(subject).select(lambda x: x*x).sum(),
+            Query(subject).select(lambda x: x*x).sum(),
             55
         )
 
@@ -599,18 +599,18 @@ class TestBasicFunctions(unittest.TestCase):
             { "value": 3 }
         ]
         self.assertEqual(
-            From(subject).select(lambda x: x["value"]).sum(),
+            Query(subject).select(lambda x: x["value"]).sum(),
             6
         )
 
     def test_tolist(self):
         self.assertListEqual(
-            From([1, 2, 3, 4]).select(lambda x: x*x).toList(),
+            Query([1, 2, 3, 4]).select(lambda x: x*x).toList(),
             [1, 4, 9, 16]
         )
 
         self.assertListEqual(
-            From([1, 2, 3, 4]).toList(),
+            Query([1, 2, 3, 4]).toList(),
             [1, 2, 3, 4]
         )
 
@@ -618,7 +618,7 @@ class TestBasicFunctions(unittest.TestCase):
         res = []
 
         subject = [1, 2, 3]
-        From(subject).forEach(lambda x: res.append(x))
+        Query(subject).forEach(lambda x: res.append(x))
         self.assertListEqual(
             res,
             subject
@@ -626,7 +626,7 @@ class TestBasicFunctions(unittest.TestCase):
 
     def test_where(self):
         expected = [2, 4]
-        obj = From(self.simple)
+        obj = Query(self.simple)
 
         result = obj.where(lambda x: x % 2 == 0).toList()
 
@@ -634,7 +634,7 @@ class TestBasicFunctions(unittest.TestCase):
 
         subject = [1, 2, 3, 4, 5, 6]
         self.assertListEqual(
-            From(subject).where(lambda x: x > 3).toList(),
+            Query(subject).where(lambda x: x > 3).toList(),
             [4, 5, 6]
         )
 
@@ -643,7 +643,7 @@ class TestBasicFunctions(unittest.TestCase):
             { "value": 3 }
         ]
         self.assertListEqual(
-            From(subject).where(lambda x: x["value"] == 3).select(lambda x: x["value"]).toList(),
+            Query(subject).where(lambda x: x["value"] == 3).select(lambda x: x["value"]).toList(),
             [3]
         )
 
@@ -675,7 +675,7 @@ class TestBasicFunctions(unittest.TestCase):
         
         self.assertListEqual(
             
-            From(students).groupJoin(
+            Query(students).groupJoin(
                 grades,
                 innerKey = lambda x: x["id"],
                 outerKey = lambda x: x["userid"],
@@ -689,7 +689,7 @@ class TestBasicFunctions(unittest.TestCase):
 
         self.assertListEqual(
 
-            From(students).groupJoin(
+            Query(students).groupJoin(
                 grades,
                 innerKey = lambda x: x["id"],
                 outerKey = lambda x: x["userid"],
@@ -703,7 +703,7 @@ class TestBasicFunctions(unittest.TestCase):
         subjA = [1, 2, 3]
         subjB = [2, 2, 3, 4]
 
-        result = From(subjA).groupJoin(
+        result = Query(subjA).groupJoin(
             subjB,
             lambda x: x,
             lambda x: x,
@@ -737,7 +737,7 @@ class TestBasicFunctions(unittest.TestCase):
                 "name": "Johan"
             }
         ]
-        names = From(students).groupJoin(
+        names = Query(students).groupJoin(
             grades,
             innerKey = lambda x: x["id"],
             outerKey = lambda x: x["userid"],
@@ -751,7 +751,7 @@ class TestBasicFunctions(unittest.TestCase):
             expected
         )
 
-        grades = From(students).groupJoin(
+        grades = Query(students).groupJoin(
             grades,
             innerKey = lambda x: x["id"],
             outerKey = lambda x: x["userid"],
@@ -770,7 +770,7 @@ class TestBasicFunctions(unittest.TestCase):
         subjB = [2, 3, 4, 5, 6]
         self.assertListEqual(
             
-            From(subjA).join(
+            Query(subjA).join(
                 subjB,
                 lambda x: x,
                 lambda x: x+1,
@@ -826,7 +826,7 @@ class TestBasicFunctions(unittest.TestCase):
         ]
 
         result = (
-            From(subject1)
+            Query(subject1)
             .join(
                 subject2,
                 lambda x: x["id"],
@@ -857,77 +857,77 @@ class TestBasicFunctions(unittest.TestCase):
 
     def test_take(self):
         self.assertListEqual(
-            From([1, 2, 3]).take(2).toList(),
+            Query([1, 2, 3]).take(2).toList(),
             [1, 2]
         )
 
     def test_takewhile(self):
         self.assertListEqual(
-            From([1, 2, 3, 4, 5, 6]).takeWhile(lambda x: x % 3 != 0).toList(),
+            Query([1, 2, 3, 4, 5, 6]).takeWhile(lambda x: x % 3 != 0).toList(),
             [1, 2]
         )
 
     def test_order(self):
         self.assertListEqual(
-            From([1, 2, 4, 3, 7, 6, 5]).order(descending=True).toList(),
+            Query([1, 2, 4, 3, 7, 6, 5]).order(descending=True).toList(),
             [7, 6, 5, 4, 3, 2, 1]
         )
 
         self.assertListEqual(
-            From([1, 2, 4, 3, 7, 6, 5]).order().toList(),
+            Query([1, 2, 4, 3, 7, 6, 5]).order().toList(),
             [1, 2, 3, 4, 5, 6, 7]
         )
 
         self.assertListEqual(
-            From([1, 2, 4, 3, 7, 6, 5]).order(key=lambda x: x % 3).toList(),
+            Query([1, 2, 4, 3, 7, 6, 5]).order(key=lambda x: x % 3).toList(),
             [3, 6, 1, 4, 7, 2, 5]
         )
 
     def test_union(self):
         self.assertListEqual(
-            From([1, 2, 3]).union([3, 4, 5]).toList(),
+            Query([1, 2, 3]).union([3, 4, 5]).toList(),
             [1, 2, 3, 4, 5]
         )
 
         self.assertListEqual(
-            From([1, 2, 3]).union([3, 4, 5], key = lambda x: x % 4).toList(),
+            Query([1, 2, 3]).union([3, 4, 5], key = lambda x: x % 4).toList(),
             [1, 2, 3, 4] # Note 5 == 2 in modulo 4
         )
 
         self.assertListEqual(
-            From([1, 2, 3]).union([3, 4, 5]).select(lambda x: x+1).toList(),
+            Query([1, 2, 3]).union([3, 4, 5]).select(lambda x: x+1).toList(),
             [2, 3, 4, 5, 6]
         )
 
     def test_wrapper(self):
         with self.assertRaises(ValueError):
-            From(1)
+            Query(1)
 
-        From("a")
-        From([1,2,3])
+        Query("a")
+        Query([1,2,3])
 
         self.assertTrue(True)
 
     def test_skip(self):
         self.assertListEqual(
-            From([1,2,3,4,5,6,7]).skip(3).toList(),
+            Query([1,2,3,4,5,6,7]).skip(3).toList(),
             [4,5,6,7]
         )
 
     def test_skipWhile(self):
         self.assertListEqual(
-            From([1,2,3,4,5,6,7]).skipWhile(lambda x: x < 3).toList(),
+            Query([1,2,3,4,5,6,7]).skipWhile(lambda x: x < 3).toList(),
             [3,4,5,6,7]
         )
 
         self.assertListEqual(
-            From([1,2,3,4,5,6,7]).skipWhile(lambda x: x % 3 != 0).toList(),
+            Query([1,2,3,4,5,6,7]).skipWhile(lambda x: x % 3 != 0).toList(),
             [3,4,5,6,7]
         )
 
     def test_toDict(self):
         self.assertDictEqual(
-            From([1,2,3,4]).toDict(lambda x: str(x*x)),
+            Query([1,2,3,4]).toDict(lambda x: str(x*x)),
             {
                 '1': 1,
                 '4': 2,
@@ -937,7 +937,7 @@ class TestBasicFunctions(unittest.TestCase):
         )
 
         self.assertDictEqual(
-            From([1,2,3,4]).toDict(lambda x: str(x), transform = lambda x: x*x),
+            Query([1,2,3,4]).toDict(lambda x: str(x), transform = lambda x: x*x),
             {
                 '1': 1,
                 '2': 4,
@@ -947,4 +947,4 @@ class TestBasicFunctions(unittest.TestCase):
         )
 
         with self.assertRaises(KeyError):
-            From([1,2,3,4]).toDict(lambda x: str(x % 3))
+            Query([1,2,3,4]).toDict(lambda x: str(x % 3))


### PR DESCRIPTION
`python_linq` -> `linq`
`From` -> `Query`
errors now found under `linq.errors`